### PR TITLE
Trigger update proto parser at startup

### DIFF
--- a/src/main/java/com/gojek/beast/com/gojek/beast/protomapping/ProtoUpdateListener.java
+++ b/src/main/java/com/gojek/beast/com/gojek/beast/protomapping/ProtoUpdateListener.java
@@ -38,6 +38,13 @@ public class ProtoUpdateListener extends com.gojek.de.stencil.cache.ProtoUpdateL
     private void createStencilClient() {
         if (protoMappingConfig.isAutoSchemaUpdateEnabled()) {
             stencilClient = StencilClientFactory.getClient(appConfig.getStencilUrl(), System.getenv(), Stats.client().getStatsDClient(), this);
+
+            log.info("updating bq table at startup", getProto());
+            try {
+                updateProtoParser();
+            } catch (ExternalCallException e) {
+                log.warn("Error while updating bigquery table:" + e.getMessage());
+            }
         } else {
             stencilClient = StencilClientFactory.getClient(appConfig.getStencilUrl(), System.getenv(), Stats.client().getStatsDClient());
         }

--- a/src/test/java/com/gojek/beast/com/gojek/beast/protomapping/ProtoUpdateListenerTest.java
+++ b/src/test/java/com/gojek/beast/com/gojek/beast/protomapping/ProtoUpdateListenerTest.java
@@ -49,7 +49,7 @@ public class ProtoUpdateListenerTest {
 
         protoUpdateListener.onProtoUpdate();
 
-        verify(updateTableService, Mockito.times(2)).getProtoMappingFromRemoteURL(protoMappingConfig.getProtoColumnMappingURL(), appConfig.getProtoSchema());
+        verify(updateTableService, Mockito.times(3)).getProtoMappingFromRemoteURL(protoMappingConfig.getProtoColumnMappingURL(), appConfig.getProtoSchema());
         verify(updateTableService).updateBigQuerySchema(eq(protoMappingConfig.getUpdateBQTableURL()), eq(updateBQTableRequestArgumentCaptor.getValue()));
         ColumnMapping actualNewProtoMapping = protoMappingConfig.getProtoColumnMapping();
         Assert.assertEquals("test-1", actualNewProtoMapping.getProperty("1"));
@@ -74,7 +74,7 @@ public class ProtoUpdateListenerTest {
         when(updateTableService.updateBigQuerySchema(eq(protoMappingConfig.getUpdateBQTableURL()), updateBQTableRequestArgumentCaptor.capture())).thenThrow(new ExternalCallException("update bq table call exception"));
 
         protoUpdateListener.onProtoUpdate();
-        verify(updateTableService, Mockito.times(2)).getProtoMappingFromRemoteURL(protoMappingConfig.getProtoColumnMappingURL(), appConfig.getProtoSchema());
+        verify(updateTableService, Mockito.times(3)).getProtoMappingFromRemoteURL(protoMappingConfig.getProtoColumnMappingURL(), appConfig.getProtoSchema());
         verify(updateTableService).updateBigQuerySchema(eq(protoMappingConfig.getUpdateBQTableURL()), eq(updateBQTableRequestArgumentCaptor.getValue()));
         ColumnMapping actualNewProtoMapping = protoMappingConfig.getProtoColumnMapping();
         Assert.assertEquals(expectedProtoMapping, actualNewProtoMapping);


### PR DESCRIPTION
Current schema auto update doesn't work if it crashed before TTL timeout and it's deployed on Kubernetes. It will Restart the pod and will deserialize the message with the new proto before Bigquery dataset get updated.