### PR TITLE
Add support for date field type 

### DIFF
--- a/src/main/java/com/gojek/beast/converter/FieldFactory.java
+++ b/src/main/java/com/gojek/beast/converter/FieldFactory.java
@@ -7,6 +7,7 @@ import com.gojek.beast.converter.fields.NestedField;
 import com.gojek.beast.converter.fields.ProtoField;
 import com.gojek.beast.converter.fields.StructField;
 import com.gojek.beast.converter.fields.TimestampField;
+import com.gojek.beast.converter.fields.DateField;
 import com.google.protobuf.Descriptors;
 
 import java.util.Arrays;
@@ -18,6 +19,7 @@ public class FieldFactory {
     public static ProtoField getField(Descriptors.FieldDescriptor descriptor, Object fieldValue) {
         List<ProtoField> protoFields = Arrays.asList(
                 new TimestampField(descriptor, fieldValue),
+                new DateField(descriptor, fieldValue),
                 new EnumField(descriptor, fieldValue),
                 new ByteField(descriptor, fieldValue),
                 new StructField(descriptor, fieldValue),

--- a/src/main/java/com/gojek/beast/converter/fields/DateField.java
+++ b/src/main/java/com/gojek/beast/converter/fields/DateField.java
@@ -2,7 +2,6 @@ package com.gojek.beast.converter.fields;
 
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.DynamicMessage;
-import com.google.type.Date;
 import lombok.AllArgsConstructor;
 
 import java.util.ArrayList;

--- a/src/main/java/com/gojek/beast/converter/fields/DateField.java
+++ b/src/main/java/com/gojek/beast/converter/fields/DateField.java
@@ -1,8 +1,8 @@
 package com.gojek.beast.converter.fields;
 
-import com.google.cloud.Date;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.DynamicMessage;
+import com.google.type.Date;
 import lombok.AllArgsConstructor;
 
 import java.util.ArrayList;
@@ -22,7 +22,7 @@ public class DateField implements ProtoField {
         Integer year = (Integer) dateFields.get(0);
         Integer month = (Integer) dateFields.get(1);
         Integer day = (Integer) dateFields.get(2);
-        return Date.fromYearMonthDay(year, month, day);
+        return com.google.cloud.Date.fromYearMonthDay(year, month, day).toString();
     }
 
     @Override

--- a/src/main/java/com/gojek/beast/converter/fields/DateField.java
+++ b/src/main/java/com/gojek/beast/converter/fields/DateField.java
@@ -1,0 +1,33 @@
+package com.gojek.beast.converter.fields;
+
+import com.google.cloud.Date;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.DynamicMessage;
+import lombok.AllArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@AllArgsConstructor
+public class DateField implements ProtoField {
+    private final Descriptors.FieldDescriptor descriptor;
+    private final Object fieldValue;
+
+    @Override
+    public Object getValue() {
+        DynamicMessage dynamicField = (DynamicMessage) fieldValue;
+        List<Descriptors.FieldDescriptor> descriptors = dynamicField.getDescriptorForType().getFields();
+        List<Object> dateFields = new ArrayList<>();
+        descriptors.forEach(desc -> dateFields.add(dynamicField.getField(desc)));
+        Integer year = (Integer) dateFields.get(0);
+        Integer month = (Integer) dateFields.get(1);
+        Integer day = (Integer) dateFields.get(2);
+        return Date.fromYearMonthDay(year, month, day);
+    }
+
+    @Override
+    public boolean matches() {
+        return descriptor.getJavaType().name().equals("MESSAGE")
+                && descriptor.getMessageType().getFullName().equals(com.google.type.Date.getDescriptor().getFullName());
+    }
+}

--- a/src/test/java/com/gojek/beast/converter/FieldFactoryTest.java
+++ b/src/test/java/com/gojek/beast/converter/FieldFactoryTest.java
@@ -9,6 +9,7 @@ import com.gojek.beast.converter.fields.EnumField;
 import com.gojek.beast.converter.fields.NestedField;
 import com.gojek.beast.converter.fields.ProtoField;
 import com.gojek.beast.converter.fields.TimestampField;
+import com.gojek.beast.converter.fields.DateField;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.Duration;
@@ -41,6 +42,7 @@ public class FieldFactoryTest {
                 .setUserToken(ByteString.copyFrom("token".getBytes()))
                 .setTripDuration(Duration.newBuilder().setSeconds(1).setNanos(1000000000).build())
                 .addAliases("alias1").addAliases("alias2").addAliases("alias3")
+                .setOrderDate(com.google.type.Date.newBuilder().setYear(1996).setMonth(11).setDay(11))
                 .build();
     }
 
@@ -51,6 +53,15 @@ public class FieldFactoryTest {
         ProtoField protoField = FieldFactory.getField(timestampDesc, message.getField(timestampDesc));
 
         assertEquals(TimestampField.class.getName(), protoField.getClass().getName());
+    }
+
+    @Test
+    public void shouldReturnDateField() {
+        Descriptors.FieldDescriptor dateDesc = message.getDescriptorForType().findFieldByNumber(14);
+
+        ProtoField protoField = FieldFactory.getField(dateDesc, message.getField(dateDesc));
+
+        assertEquals(DateField.class.getName(), protoField.getClass().getName());
     }
 
     @Test

--- a/src/test/java/com/gojek/beast/converter/RowMapperTest.java
+++ b/src/test/java/com/gojek/beast/converter/RowMapperTest.java
@@ -10,6 +10,7 @@ import com.gojek.beast.util.ProtoUtil;
 import com.gojek.de.stencil.StencilClientFactory;
 import com.gojek.de.stencil.parser.ProtoParser;
 import com.google.api.client.util.DateTime;
+import com.google.cloud.Date;
 import com.google.protobuf.*;
 import org.junit.Before;
 import org.junit.Test;
@@ -42,6 +43,7 @@ public class RowMapperTest {
                 .setOrderDetails("order-details")
                 .setCreatedAt(createdAt)
                 .setStatus(Status.COMPLETED)
+                .setOrderDate(com.google.type.Date.newBuilder().setYear(1996).setMonth(11).setDay(21))
                 .build();
         dynamicMessage = protoParser.parse(testMessage.toByteArray());
         nowMillis = Instant.ofEpochSecond(now.getEpochSecond(), now.getNano()).toEpochMilli();
@@ -55,6 +57,7 @@ public class RowMapperTest {
         fieldMappings.put("3", "order_details_field");
         fieldMappings.put("4", "created_at");
         fieldMappings.put("5", "order_status");
+        fieldMappings.put("14", "order_date_field");
 
         Map<String, Object> fields = new RowMapper(fieldMappings).map(dynamicMessage);
 
@@ -63,6 +66,7 @@ public class RowMapperTest {
         assertEquals("order-details", fields.get("order_details_field"));
         assertEquals(new DateTime(nowMillis), fields.get("created_at"));
         assertEquals("COMPLETED", fields.get("order_status"));
+        assertEquals(Date.fromYearMonthDay(1996, 11, 21), fields.get("order_date_field"));
         assertEquals(fieldMappings.size(), fields.size());
     }
 

--- a/src/test/java/com/gojek/beast/converter/RowMapperTest.java
+++ b/src/test/java/com/gojek/beast/converter/RowMapperTest.java
@@ -10,7 +10,6 @@ import com.gojek.beast.util.ProtoUtil;
 import com.gojek.de.stencil.StencilClientFactory;
 import com.gojek.de.stencil.parser.ProtoParser;
 import com.google.api.client.util.DateTime;
-import com.google.cloud.Date;
 import com.google.protobuf.*;
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/com/gojek/beast/converter/RowMapperTest.java
+++ b/src/test/java/com/gojek/beast/converter/RowMapperTest.java
@@ -66,7 +66,7 @@ public class RowMapperTest {
         assertEquals("order-details", fields.get("order_details_field"));
         assertEquals(new DateTime(nowMillis), fields.get("created_at"));
         assertEquals("COMPLETED", fields.get("order_status"));
-        assertEquals(Date.fromYearMonthDay(1996, 11, 21), fields.get("order_date_field"));
+        assertEquals("1996-11-21", fields.get("order_date_field"));
         assertEquals(fieldMappings.size(), fields.size());
     }
 

--- a/src/test/java/com/gojek/beast/converter/RowMapperTest.java
+++ b/src/test/java/com/gojek/beast/converter/RowMapperTest.java
@@ -286,4 +286,31 @@ public class RowMapperTest {
 
         new RowMapper(null).map(dynamicMessage);
     }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowIllegalArgumentExceptionOnInvalidDate() throws InvalidProtocolBufferException {
+        TestMessage testMessage = TestMessage.newBuilder()
+                .setOrderDate(com.google.type.Date.newBuilder().setYear(1996).setMonth(13).setDay(21))
+                .build();
+        ProtoParser protoParser = new ProtoParser(StencilClientFactory.getClient(), TestMessage.class.getName());
+        dynamicMessage = protoParser.parse(testMessage.toByteArray());
+        ColumnMapping fieldMappings = new ColumnMapping();
+        fieldMappings.put("14", "order_date_field");
+
+        Map<String, Object> fields = new RowMapper(fieldMappings).map(dynamicMessage);
+    }
+
+    @Test
+    public void shouldReturnNullWhenNoDateFieldIsProvided() throws InvalidProtocolBufferException {
+        TestMessage testMessage = TestMessage.newBuilder()
+                .build();
+        ProtoParser protoParser = new ProtoParser(StencilClientFactory.getClient(), TestMessage.class.getName());
+        dynamicMessage = protoParser.parse(testMessage.toByteArray());
+        ColumnMapping fieldMappings = new ColumnMapping();
+        fieldMappings.put("14", "order_date_field");
+
+        Map<String, Object> fields = new RowMapper(fieldMappings).map(dynamicMessage);
+
+        assertNull(fields.get("order_date_field"));
+    }
 }

--- a/src/test/proto/TestMessage.proto
+++ b/src/test/proto/TestMessage.proto
@@ -5,6 +5,7 @@ package com.gojek.beast;
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
+import "google/type/date.proto";
 
 option java_multiple_files = true;
 option java_package = "com.gojek.beast";
@@ -29,6 +30,7 @@ message TestMessage {
     google.protobuf.Duration trip_duration = 11;
     repeated string aliases = 12;
     google.protobuf.Struct properties = 13;
+    google.type.Date order_date = 14;
 }
 
 message TestNestedMessage {


### PR DESCRIPTION
This will add support for beast to consume a type of  _**com.google.type.Date_**

This is needed as the existing timestamp type contains information about time as well and is not suited to cover only date type.