### PR TITLE
Handle more out of conditions for DLQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ Kafka to BigQuery Sink
     GCS_PATH_PREFIX=<prefix path under the bucket>
     GCS_WRITER_PROJECT_NAME=<google project having bucket>
     ```
-    The handler partitions the invalid messages on GCS based on the message arrival date in the format `<dt=yyyy-MM-dd>`. The location of invalid messages on GCS would ideally be `<GCS_WRITER_PROJECT_NAME>/<GCS_BUCKET>/<GCS_PATH_PREFIX>/<dt=yyyy-MM-dd>/<topicName>/<random-uuid>`
-    - where <topicName> - is the topic that has the invalid messages
-    - <random-uuid> - name of the file
+    The handler partitions the invalid messages on GCS based on the message arrival date in the format `<dt=yyyy-MM-dd>`. The location of invalid messages on GCS would ideally be `<GCS_WRITER_PROJECT_NAME>/<GCS_BUCKET>/<GCS_PATH_PREFIX>/<dt=yyyy-MM-dd>/<topicName>/<random-uuid>` where
+    - `<topicName>` - is the topic that has the invalid messages
+    - `<random-uuid>` - name of the file
 
 ## Building & Running
 

--- a/src/main/java/com/gojek/beast/factory/BeastFactory.java
+++ b/src/main/java/com/gojek/beast/factory/BeastFactory.java
@@ -108,7 +108,7 @@ public class BeastFactory {
         ErrorWriter errorWriter = new DefaultLogWriter();
         if (appConfig.isGCSErrorSinkEnabled()) {
             final String bucketName = appConfig.getGcsBucket();
-            final String basePathPrefix = bucketName + "/" + appConfig.getGcsPathPrefix();
+            final String basePathPrefix = appConfig.getGcsPathPrefix();
             errorWriter = new GCSErrorWriter(gcsStore, bucketName, basePathPrefix);
         }
         return new OOBErrorHandler(errorWriter);

--- a/src/main/java/com/gojek/beast/sink/bq/handler/error/OOBDescriptor.java
+++ b/src/main/java/com/gojek/beast/sink/bq/handler/error/OOBDescriptor.java
@@ -17,8 +17,8 @@ public class OOBDescriptor implements ErrorDescriptor {
     @Override
     public boolean matches() {
         return reason.equals("invalid")
-                && message.contains("is outside the allowed bounds")
-                && message.contains("365 days in the past and 183 days in the future");
+                && ((message.contains("is outside the allowed bounds") && message.contains("365 days in the past and 183 days in the future"))
+                    || message.contains("out of range"));
     }
 
 }

--- a/src/main/java/com/gojek/beast/sink/bq/handler/impl/OOBErrorHandler.java
+++ b/src/main/java/com/gojek/beast/sink/bq/handler/impl/OOBErrorHandler.java
@@ -38,6 +38,8 @@ public class OOBErrorHandler implements BQErrorHandler {
                         break;
                     case INVALID: recordHasInvalidData = true;
                         break;
+                    case UNKNOWN: shouldBatchFail = true;
+                        break;
                     default:
                 }
             } //end of for each row

--- a/src/test/java/com/gojek/beast/sink/bq/handler/error/ErrorTypeFactoryTest.java
+++ b/src/test/java/com/gojek/beast/sink/bq/handler/error/ErrorTypeFactoryTest.java
@@ -31,5 +31,6 @@ public class ErrorTypeFactoryTest {
     @Test
     public void testErrorTypeIsOutOfBounds() {
         assertEquals(BQInsertionRecordsErrorType.OOB, ErrorTypeFactory.getErrorType("invalid", "is outside the allowed bounds, 365 days in the past and 183 days in the future"));
+        assertEquals(BQInsertionRecordsErrorType.OOB, ErrorTypeFactory.getErrorType("invalid", "out of range"));
     }
 }


### PR DESCRIPTION
BQ Insert errors have more error types and text for out of bounds. The handler is updated accordingly.