### PR TITLE
[dBTCH-322][Maulik] update stencil version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     }
 
     compile group: 'org.apache.kafka', name: 'kafka-clients', version: '2.0.0'
-    compile group: 'com.gojek', name: 'stencil', version: '3.0.0'
+    compile group: 'com.gojek', name: 'stencil', version: '4.0.1'
     compile group: 'com.timgroup', name: 'java-statsd-client', version: '3.1.0'
     compile group: 'com.getsentry.raven', name: 'raven', version: '8.0.3'
     compile group: 'com.getsentry.raven', name: 'raven-logback', version: '7.8.0'

--- a/src/main/java/com/gojek/beast/sink/bq/BQClient.java
+++ b/src/main/java/com/gojek/beast/sink/bq/BQClient.java
@@ -58,6 +58,8 @@ public class BQClient {
                 log.info("Successfully UPDATED bigquery TABLE: {}", tableID.getTable());
                 statsClient.timeIt("bq.upsert.table.time," + statsClient.getBqTags(), start);
                 statsClient.increment("bq.upsert.table.count," + statsClient.getBqTags());
+            } else {
+                log.info("Skipping bigquery table update, since proto schema hasn't changed");
             }
         }
     }


### PR DESCRIPTION
Remove dependency on ProtoUpdateListener to check if the descriptor has changed.

As part of this change, we are not dependent on stencil to give callback when proto has changed.
Instead, we get a callback when the cache is invalidated and new proto is fetched.
Historically, this was added to stencil so that we don't make a call to update schema when the cache invalidates and schema hasn't changed

We currently have checks in`BQClient` that compares the updated schema with existing schema,  before making the call to update schema.
After this change, we don't rely on stencil's checks of comparing the descriptor.
Instead, we will rely on comparing the existing schema with the new schema.