### PR TITLE
[Chakravarthy|dV2_BQ_API] - Enables config for setting transport options

### DIFF
--- a/src/main/java/com/gojek/beast/config/BQConfig.java
+++ b/src/main/java/com/gojek/beast/config/BQConfig.java
@@ -25,4 +25,12 @@ public interface BQConfig extends Config {
     @DefaultValue("true")
     @Key("ENABLE_BQ_ROW_INSERTID")
     Boolean isBQRowInsertIdEnabled();
+
+    @DefaultValue("-1")
+    @Key("BQ_CLIENT_READ_TIMEOUT")
+    String getBqClientReadTimeout();
+
+    @DefaultValue("-1")
+    @Key("BQ_CLIENT_CONNECT_TIMEOUT")
+    String getBqClientConnectTimeout();
 }

--- a/src/main/java/com/gojek/beast/models/FailureStatus.java
+++ b/src/main/java/com/gojek/beast/models/FailureStatus.java
@@ -28,7 +28,7 @@ public class FailureStatus implements Status {
     @Override
     public String toString() {
         return "FailureStatus{"
-                + "cause=" + cause.getMessage()
-                + ", message='" + message + '\'' + '}';
+                + "cause=" + cause.getCause()
+                + ", message='" + ((message != null) ? message : cause.getMessage()) + '\'' + '}';
     }
 }

--- a/src/main/java/com/gojek/beast/sink/executor/RetryExecutor.java
+++ b/src/main/java/com/gojek/beast/sink/executor/RetryExecutor.java
@@ -50,6 +50,7 @@ public class RetryExecutor implements Executor {
         try {
             status = sink.push(records);
         } catch (Exception e) {
+            statsClient.increment("retrysink.exec.failure.count," + statsClient.getBqTags());
             status = new FailureStatus(e);
         }
         ifFailure();


### PR DESCRIPTION
Google v2 streaming backend allows an increased bandwidth than the previous versions upto 1 GB/Sec at project level. Moving to v2 has produced intermittent connection failures on timeouts and the impacts show an increased processing time on bq server side by 3-4x times than the previous v1.

Enabling metrics on push failures in beast shows that there are 15K push failures in 24 hours. 

Based on the support ticket with google, and with recommendation from google, this story/feature  provides a configurable setting for read timeout and connection timeout
