### PR TITLE
[Maulik] use offsets map in commit queue instead of records

### DIFF
--- a/src/main/java/com/gojek/beast/sink/OffsetMapQueueSink.java
+++ b/src/main/java/com/gojek/beast/sink/OffsetMapQueueSink.java
@@ -1,0 +1,46 @@
+package com.gojek.beast.sink;
+
+import com.gojek.beast.config.QueueConfig;
+import com.gojek.beast.models.FailureStatus;
+import com.gojek.beast.models.Records;
+import com.gojek.beast.models.Status;
+import com.gojek.beast.models.SuccessStatus;
+import com.gojek.beast.stats.Stats;
+import lombok.AllArgsConstructor;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+
+@AllArgsConstructor
+public class OffsetMapQueueSink implements Sink {
+    private final Stats statsClient = Stats.client();
+    private final BlockingQueue<Map<TopicPartition, OffsetAndMetadata>> recordQueue;
+    private final QueueConfig config;
+
+    @Override
+    public Status push(Records records) {
+        Instant start = Instant.now();
+        boolean offered;
+        Map<TopicPartition, OffsetAndMetadata> offsetmap = records.getPartitionsCommitOffset();
+        try {
+            offered = recordQueue.offer(offsetmap, config.getTimeout(), config.getTimeoutUnit());
+            statsClient.gauge("queue.elements,name=" + config.getName(), recordQueue.size());
+        } catch (InterruptedException e) {
+            return new FailureStatus(e);
+        }
+        statsClient.count("sink.queue.push.messages", offsetmap.size());
+        statsClient.timeIt("sink.queue.push.time", start);
+        return offered ? new SuccessStatus()
+                : new FailureStatus(new RuntimeException(String.format("%s queue is full with capacity: %d", config.getName(), recordQueue.size())));
+
+    }
+
+
+    @Override
+    public void close(String reason) {
+
+    }
+}

--- a/src/main/java/com/gojek/beast/sink/RecordsQueueSink.java
+++ b/src/main/java/com/gojek/beast/sink/RecordsQueueSink.java
@@ -12,7 +12,7 @@ import java.time.Instant;
 import java.util.concurrent.BlockingQueue;
 
 @AllArgsConstructor
-public class QueueSink implements Sink {
+public class RecordsQueueSink implements Sink {
     private final Stats statsClient = Stats.client();
     private final BlockingQueue<Records> recordQueue;
     private final QueueConfig config;

--- a/src/main/java/com/gojek/beast/worker/OffsetCommitWorker.java
+++ b/src/main/java/com/gojek/beast/worker/OffsetCommitWorker.java
@@ -5,11 +5,10 @@ import com.gojek.beast.commiter.KafkaCommitter;
 import com.gojek.beast.commiter.OffsetState;
 import com.gojek.beast.config.QueueConfig;
 import com.gojek.beast.models.FailureStatus;
+import com.gojek.beast.models.Status;
 import com.gojek.beast.models.OffsetMetadata;
 import com.gojek.beast.models.SuccessStatus;
 import com.gojek.beast.stats.Stats;
-import com.gojek.beast.models.Records;
-import com.gojek.beast.models.Status;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
@@ -24,7 +23,7 @@ import java.util.concurrent.BlockingQueue;
 public class OffsetCommitWorker extends Worker {
     private static final int DEFAULT_SLEEP_MS = 100;
     private final Stats statsClient = Stats.client();
-    private final BlockingQueue<Records> commitQueue;
+    private final BlockingQueue<Map<TopicPartition, OffsetAndMetadata>> commitQueue;
     private final QueueConfig queueConfig;
     private final KafkaCommitter kafkaCommitter;
     @Setter
@@ -33,7 +32,7 @@ public class OffsetCommitWorker extends Worker {
     private OffsetState offsetState;
     private Clock clock;
 
-    public OffsetCommitWorker(String name, QueueConfig queueConfig, KafkaCommitter kafkaCommitter, OffsetState offsetState, BlockingQueue<Records> commitQueue, WorkerState workerState, Clock clock) {
+    public OffsetCommitWorker(String name, QueueConfig queueConfig, KafkaCommitter kafkaCommitter, OffsetState offsetState, BlockingQueue<Map<TopicPartition, OffsetAndMetadata>> commitQueue, WorkerState workerState, Clock clock) {
         super(name, workerState);
         this.clock = clock;
         this.queueConfig = queueConfig;
@@ -61,20 +60,18 @@ public class OffsetCommitWorker extends Worker {
 
             int offsetClubbedBatches = 0;
             while (true) {
-                Records commitOffset = commitQueue.poll(queueConfig.getTimeout(), queueConfig.getTimeoutUnit());
+                Map<TopicPartition, OffsetAndMetadata> currentOffset = commitQueue.poll(queueConfig.getTimeout(), queueConfig.getTimeoutUnit());
                 if (stopped || clock.currentEpochMillis() - start > offsetState.getOffsetBatchDuration()) {
                     break;
                 }
 
-                if (commitOffset == null) {
+                if (currentOffset == null) {
                     continue;
                 }
 
-                Map<TopicPartition, OffsetAndMetadata> currentOffset = commitOffset.getPartitionsCommitOffset();
                 Instant commitQueuePollStartTime = Instant.now();
                 while (true) {
                     if (offsetState.removeFromOffsetAck(currentOffset)) {
-
                         currentOffset.keySet().forEach(topicPartition -> {
                             OffsetAndMetadata offsetAndMetadata = currentOffset.get(topicPartition);
                             OffsetMetadata previousOffset = (OffsetMetadata) partitionsCommitOffset.getOrDefault(topicPartition, new OffsetMetadata(Integer.MIN_VALUE));

--- a/src/test/java/com/gojek/beast/sink/OffsetMapQueueSinkTest.java
+++ b/src/test/java/com/gojek/beast/sink/OffsetMapQueueSinkTest.java
@@ -1,0 +1,97 @@
+package com.gojek.beast.sink;
+
+import com.gojek.beast.config.QueueConfig;
+import com.gojek.beast.models.Records;
+import com.gojek.beast.models.Status;
+import com.gojek.beast.models.OffsetInfo;
+import com.gojek.beast.models.Record;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+public class OffsetMapQueueSinkTest {
+
+    private final OffsetInfo offsetInfo = new OffsetInfo("default-topic", 0, 0, Instant.now().toEpochMilli());
+    private QueueConfig queueConfig;
+    private Sink queueSink;
+
+    @Before
+    public void setUp() throws Exception {
+        queueConfig = new QueueConfig(1000);
+    }
+
+    @Test
+    public void shouldPushMessageToQueue() throws InterruptedException {
+        BlockingQueue<Map<TopicPartition, OffsetAndMetadata>> queue = new LinkedBlockingQueue<>();
+        queueSink = new OffsetMapQueueSink(queue, queueConfig);
+        Records messages = new Records(Collections.singletonList(new Record(offsetInfo, new HashMap<>())));
+
+        Status status = queueSink.push(messages);
+
+        assertTrue(status.isSuccess());
+        assertEquals(1, queue.size());
+        Map<TopicPartition, OffsetAndMetadata> partitionsCommitOffset = queue.take();
+        assertEquals(1, partitionsCommitOffset.size());
+        Map.Entry<TopicPartition, OffsetAndMetadata> offset = partitionsCommitOffset.entrySet().iterator().next();
+        assertEquals(offset.getKey().topic(), "default-topic");
+        assertEquals(offset.getKey().partition(), 0);
+        assertEquals(offset.getValue().offset(), 1);
+    }
+
+    @Test
+    public void shouldPushMultipleMessagesToQueue() throws InterruptedException {
+        BlockingQueue<Map<TopicPartition, OffsetAndMetadata>> queue = new LinkedBlockingQueue<>();
+        queueSink = new OffsetMapQueueSink(queue, queueConfig);
+        Records messages = new Records(Arrays.asList(new Record(offsetInfo, new HashMap<>()), new Record(offsetInfo, new HashMap<>())));
+
+        Status status = queueSink.push(messages);
+
+        assertTrue(status.isSuccess());
+        assertEquals(1, queue.size());
+        Map<TopicPartition, OffsetAndMetadata> partitionsCommitOffset = queue.take();
+        assertEquals(1, partitionsCommitOffset.size());
+        Map.Entry<TopicPartition, OffsetAndMetadata> offset = partitionsCommitOffset.entrySet().iterator().next();
+        assertEquals(offset.getKey().topic(), "default-topic");
+        assertEquals(offset.getKey().partition(), 0);
+        assertEquals(offset.getValue().offset(), 1);
+    }
+
+    @Test
+    public void shouldReturnFailureStatusOnException() throws InterruptedException {
+        BlockingQueue<Map<TopicPartition, OffsetAndMetadata>> queue = mock(BlockingQueue.class);
+        Records records = new Records(Arrays.asList(new Record(offsetInfo, new HashMap<>()), new Record(offsetInfo, new HashMap<>())));
+        queueSink = new OffsetMapQueueSink(queue, queueConfig);
+        Map<TopicPartition, OffsetAndMetadata> offsetMap = records.getPartitionsCommitOffset();
+        doThrow(new InterruptedException()).when(queue).offer(offsetMap, queueConfig.getTimeout(), queueConfig.getTimeoutUnit());
+
+        Status status = queueSink.push(records);
+
+        assertFalse(status.isSuccess());
+    }
+
+    @Test
+    public void shouldReturnFailureStatusWhenQueueIsFull() {
+        BlockingQueue<Map<TopicPartition, OffsetAndMetadata>> queue = new LinkedBlockingQueue<>(1);
+        Records records = new Records(Arrays.asList(new Record(offsetInfo, new HashMap<>()), new Record(offsetInfo, new HashMap<>())));
+        queue.offer(records.getPartitionsCommitOffset());
+        queueSink = new OffsetMapQueueSink(queue, queueConfig);
+        Status status = queueSink.push(records);
+
+        assertFalse(status.isSuccess());
+    }
+}

--- a/src/test/java/com/gojek/beast/sink/RecordsQueueSinkTest.java
+++ b/src/test/java/com/gojek/beast/sink/RecordsQueueSinkTest.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 
-public class QueueSinkTest {
+public class RecordsQueueSinkTest {
 
     private final OffsetInfo offsetInfo = new OffsetInfo("default-topic", 0, 0, Instant.now().toEpochMilli());
     private QueueConfig queueConfig;
@@ -36,7 +36,7 @@ public class QueueSinkTest {
     @Test
     public void shouldPushMessageToQueue() throws InterruptedException {
         BlockingQueue<Records> queue = new LinkedBlockingQueue<>();
-        queueSink = new QueueSink(queue, queueConfig);
+        queueSink = new RecordsQueueSink(queue, queueConfig);
         Records messages = new Records(Collections.singletonList(new Record(offsetInfo, new HashMap<>())));
 
         Status status = queueSink.push(messages);
@@ -49,7 +49,7 @@ public class QueueSinkTest {
     @Test
     public void shouldPushMultipleMessagesToQueue() throws InterruptedException {
         BlockingQueue<Records> queue = new LinkedBlockingQueue<>();
-        queueSink = new QueueSink(queue, queueConfig);
+        queueSink = new RecordsQueueSink(queue, queueConfig);
         Records messages = new Records(Arrays.asList(new Record(offsetInfo, new HashMap<>()), new Record(offsetInfo, new HashMap<>())));
 
         Status status = queueSink.push(messages);
@@ -63,7 +63,7 @@ public class QueueSinkTest {
     public void shouldReturnFailureStatusOnException() throws InterruptedException {
         BlockingQueue<Records> queue = mock(BlockingQueue.class);
         Records messages = new Records(Arrays.asList(new Record(offsetInfo, new HashMap<>()), new Record(offsetInfo, new HashMap<>())));
-        queueSink = new QueueSink(queue, queueConfig);
+        queueSink = new RecordsQueueSink(queue, queueConfig);
         doThrow(new InterruptedException()).when(queue).offer(messages, queueConfig.getTimeout(), queueConfig.getTimeoutUnit());
 
         Status status = queueSink.push(messages);
@@ -76,7 +76,7 @@ public class QueueSinkTest {
         BlockingQueue<Records> queue = new LinkedBlockingQueue<>(1);
         Records messages = new Records(Arrays.asList(new Record(offsetInfo, new HashMap<>()), new Record(offsetInfo, new HashMap<>())));
         queue.offer(messages);
-        queueSink = new QueueSink(queue, queueConfig);
+        queueSink = new RecordsQueueSink(queue, queueConfig);
         Status status = queueSink.push(messages);
 
         assertFalse(status.isSuccess());


### PR DESCRIPTION
Use offsets in commit queue instead of records inorder to reduce the heap.