### PR TITLE
[Shekhar] send kafka.batch.records.count metrics with partition tag

### DIFF
--- a/src/main/java/com/gojek/beast/models/Record.java
+++ b/src/main/java/com/gojek/beast/models/Record.java
@@ -15,10 +15,14 @@ public class Record {
     private Map<String, Object> columns;
 
     public String getId() {
-        return String.format("%s_%d_%d", offsetInfo.getTopic(), offsetInfo.getPartition(), offsetInfo.getOffset());
+        return String.format("%s_%d_%d", offsetInfo.getTopic(), getPartition(), offsetInfo.getOffset());
+    }
+
+    public Integer getPartition() {
+        return offsetInfo.getPartition();
     }
 
     public long getSize() {
-        return columns.toString().getBytes(StandardCharsets.UTF_8).length;
+        return columns == null ? 0 : columns.toString().getBytes(StandardCharsets.UTF_8).length;
     }
 }

--- a/src/main/java/com/gojek/beast/models/Records.java
+++ b/src/main/java/com/gojek/beast/models/Records.java
@@ -17,6 +17,7 @@ public class Records implements Iterable<Record> {
     @Getter
     private final Instant polledTime; // time when this batch were fetched or created
     private Map<TopicPartition, OffsetAndMetadata> partitionsCommitOffset = new HashMap<>();
+    private Map<Integer, Long> recordCountByPartition = new HashMap<>();
 
     public Records(List<Record> records) {
         this(records, Instant.now());
@@ -45,9 +46,14 @@ public class Records implements Iterable<Record> {
     }
 
     public long getSize() {
-        return records.stream().mapToLong(record -> {
-            return record.getSize();
-        }).sum();
+        return records.stream().mapToLong(Record::getSize).sum();
+    }
+
+    public Map<Integer, Long> getRecordCountByPartition() {
+        if (recordCountByPartition.isEmpty()) {
+            records.forEach(r -> recordCountByPartition.merge(r.getPartition(), 1L, Long::sum));
+        }
+        return recordCountByPartition;
     }
 
     @Override

--- a/src/main/java/com/gojek/beast/worker/BqQueueWorker.java
+++ b/src/main/java/com/gojek/beast/worker/BqQueueWorker.java
@@ -58,7 +58,7 @@ public class BqQueueWorker extends Worker {
         try {
             status = sink.push(poll);
             statsClient.count("kafka.batch.records.size," + statsClient.getBqTags(), poll.getSize());
-            statsClient.count("kafka.batch.records.count," + statsClient.getBqTags(), poll.getRecords().size());
+            poll.getRecordCountByPartition().forEach((partition, recordCount) -> statsClient.count("kafka.batch.records.count," + statsClient.getBqTags() + ",partition=" + partition.toString(), recordCount));
         } catch (BigQueryException e) {
             statsClient.increment("worker.queue.bq.errors");
             log.error("Exception::Failed to write to BQ: {}", e.getMessage());

--- a/src/test/java/com/gojek/beast/models/RecordsTest.java
+++ b/src/test/java/com/gojek/beast/models/RecordsTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -62,5 +63,30 @@ public class RecordsTest {
 
         assertSame(actualMaxOffsetInfo, records.getPartitionsCommitOffset());
         assertSame(actualMaxOffsetInfo, records.getPartitionsCommitOffset());
+    }
+
+    @Test
+    public void shouldReturnCorrectRecordCountByPartition() {
+        String topic = "default-topic";
+        int partition0MaxOffset = 102;
+        int partition1MaxOffset = 105;
+        int partition0 = 0;
+        int partition1 = 1;
+        List<Record> rawRecords = Arrays.asList(
+                new Record(new OffsetInfo(topic, partition0, 100, Instant.now().toEpochMilli()), null),
+                new Record(new OffsetInfo(topic, partition0, partition0MaxOffset, Instant.now().toEpochMilli()), null),
+                new Record(new OffsetInfo(topic, partition0, 101, Instant.now().toEpochMilli()), null),
+                new Record(new OffsetInfo(topic, partition1, partition1MaxOffset, Instant.now().toEpochMilli()), null),
+                new Record(new OffsetInfo(topic, partition1, 101, Instant.now().toEpochMilli()), null),
+                new Record(new OffsetInfo(topic, partition1, 102, Instant.now().toEpochMilli()), null)
+        );
+
+        Records records = new Records(rawRecords);
+        HashMap<Integer, Long> expectedResult = new HashMap<Integer, Long>() {{
+            put(partition0, 3L);
+            put(partition1, 3L);
+        }};
+        assertEquals(expectedResult, records.getRecordCountByPartition());
+        assertEquals(0, records.getSize());
     }
 }


### PR DESCRIPTION
Currently, the statsd metric `kafka.batch.records.count` is not being sent with partition information. This change adds partition as a tag for this metric.