### PR TITLE
BEAST-55: change OOBHandler check for messages outside streaming insert range

### DIFF
--- a/src/main/java/com/gojek/beast/sink/bq/handler/error/OOBDescriptor.java
+++ b/src/main/java/com/gojek/beast/sink/bq/handler/error/OOBDescriptor.java
@@ -17,7 +17,7 @@ public class OOBDescriptor implements ErrorDescriptor {
     @Override
     public boolean matches() {
         return reason.equals("invalid")
-                && ((message.contains("is outside the allowed bounds") && message.contains("365 days in the past and 183 days in the future"))
+                && ((message.contains("is outside the allowed bounds") && message.contains("1825 days in the past and 366 days in the future"))
                     || message.contains("out of range"));
     }
 

--- a/src/test/java/com/gojek/beast/sink/bq/handler/error/ErrorTypeFactoryTest.java
+++ b/src/test/java/com/gojek/beast/sink/bq/handler/error/ErrorTypeFactoryTest.java
@@ -30,7 +30,7 @@ public class ErrorTypeFactoryTest {
 
     @Test
     public void testErrorTypeIsOutOfBounds() {
-        assertEquals(BQInsertionRecordsErrorType.OOB, ErrorTypeFactory.getErrorType("invalid", "is outside the allowed bounds, 365 days in the past and 183 days in the future"));
+        assertEquals(BQInsertionRecordsErrorType.OOB, ErrorTypeFactory.getErrorType("invalid", "is outside the allowed bounds, 1825 days in the past and 366 days in the future"));
         assertEquals(BQInsertionRecordsErrorType.OOB, ErrorTypeFactory.getErrorType("invalid", "out of range"));
     }
 }


### PR DESCRIPTION
Address #55 

The message check has been changed as mentioned in the doc: https://cloud.google.com/bigquery/streaming-data-into-bigquery#streaming_into_partitioned_tables