### PR TITLE
[Kush] Support for struct repeated field serialization

### DIFF
--- a/src/main/java/com/gojek/beast/config/MapPropertyConverter.java
+++ b/src/main/java/com/gojek/beast/config/MapPropertyConverter.java
@@ -15,6 +15,9 @@ public class MapPropertyConverter implements Converter<Map<String, String>> {
         String[] chunks = input.split(ELEMENT_SEPARATOR, -1);
         for (String chunk : chunks) {
             String[] entry = chunk.split(VALUE_SEPARATOR, -1);
+            if (entry.length <= 1) {
+                continue;
+            }
             String key = entry[0].trim();
             String value = entry[1].trim();
             result.put(key, value);

--- a/src/main/java/com/gojek/beast/converter/fields/StructField.java
+++ b/src/main/java/com/gojek/beast/converter/fields/StructField.java
@@ -6,6 +6,10 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
 import lombok.AllArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
 @AllArgsConstructor
 public class StructField implements ProtoField {
     private final Descriptors.FieldDescriptor descriptor;
@@ -14,12 +18,23 @@ public class StructField implements ProtoField {
     @Override
     public Object getValue() {
         try {
-            return JsonFormat.printer()
-                    .omittingInsignificantWhitespace()
-                    .print((DynamicMessage) fieldValue);
+            if (fieldValue instanceof Collection<?>) {
+                List<String> structStrValues = new ArrayList<>();
+                for (Object field: (Collection<?>) fieldValue) {
+                    structStrValues.add(getString(field));
+                }
+                return structStrValues;
+            }
+            return getString(fieldValue);
         } catch (InvalidProtocolBufferException e) {
             return "";
         }
+    }
+
+    private String getString(Object field) throws InvalidProtocolBufferException {
+        return JsonFormat.printer()
+                .omittingInsignificantWhitespace()
+                .print((DynamicMessage) field);
     }
 
     @Override

--- a/src/main/java/com/gojek/beast/converter/fields/TimestampField.java
+++ b/src/main/java/com/gojek/beast/converter/fields/TimestampField.java
@@ -7,6 +7,7 @@ import lombok.AllArgsConstructor;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 @AllArgsConstructor
@@ -16,7 +17,19 @@ public class TimestampField implements ProtoField {
 
     @Override
     public Object getValue() {
-        DynamicMessage dynamicField = (DynamicMessage) fieldValue;
+        if (fieldValue instanceof Collection<?>) {
+            List<DateTime> tsValues = new ArrayList<>();
+            for (Object field: (Collection<?>) fieldValue) {
+                tsValues.add(getTime(field));
+            }
+            return tsValues;
+        }
+
+        return getTime(fieldValue);
+    }
+
+    private DateTime getTime(Object field) {
+        DynamicMessage dynamicField = (DynamicMessage) field;
         List<Descriptors.FieldDescriptor> descriptors = dynamicField.getDescriptorForType().getFields();
         List<Object> timeFields = new ArrayList<>();
         descriptors.forEach(desc -> timeFields.add(dynamicField.getField(desc)));

--- a/src/test/java/com/gojek/beast/config/MapPropertyConverterTest.java
+++ b/src/test/java/com/gojek/beast/config/MapPropertyConverterTest.java
@@ -1,0 +1,42 @@
+package com.gojek.beast.config;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class MapPropertyConverterTest {
+
+    @Test
+    public void shouldhandleNonEmptyProperty() throws Exception {
+        String attributes = "label1=val1";
+        Map<String, String> props = new MapPropertyConverter().convert(null, attributes);
+
+        Map<String, String> expectedProperties = new HashMap<>();
+        expectedProperties.put("label1", "val1");
+
+        assertEquals(expectedProperties, props);
+    }
+
+    @Test
+    public void shouldhandleEmptyProperty() throws Exception {
+        String attributes = "label1=";
+        Map<String, String> props = new MapPropertyConverter().convert(null, attributes);
+
+        Map<String, String> expectedProperties = new HashMap<>();
+        expectedProperties.put("label1", "");
+
+        assertEquals(expectedProperties, props);
+    }
+
+    @Test
+    public void shouldhandleEmptyRequest() throws Exception {
+        String attributes = "";
+        Map<String, String> props = new MapPropertyConverter().convert(null, attributes);
+
+        Map<String, String> expectedProperties = new HashMap<>();
+        assertEquals(expectedProperties, props);
+    }
+}

--- a/src/test/java/com/gojek/beast/converter/FieldFactoryTest.java
+++ b/src/test/java/com/gojek/beast/converter/FieldFactoryTest.java
@@ -8,11 +8,15 @@ import com.gojek.beast.converter.fields.DefaultProtoField;
 import com.gojek.beast.converter.fields.EnumField;
 import com.gojek.beast.converter.fields.NestedField;
 import com.gojek.beast.converter.fields.ProtoField;
+import com.gojek.beast.converter.fields.StructField;
 import com.gojek.beast.converter.fields.TimestampField;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.Duration;
 import com.google.protobuf.Timestamp;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import com.google.type.Date;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -30,6 +34,7 @@ public class FieldFactoryTest {
     @Before
     public void setUp() throws Exception {
         Instant now = Instant.now();
+
         createdAt = Timestamp.newBuilder().setSeconds(now.getEpochSecond()).setNanos(now.getNano()).build();
         message = TestMessage.newBuilder()
                 .setOrderNumber("order-1")
@@ -41,17 +46,38 @@ public class FieldFactoryTest {
                 .setUserToken(ByteString.copyFrom("token".getBytes()))
                 .setTripDuration(Duration.newBuilder().setSeconds(1).setNanos(1000000000).build())
                 .addAliases("alias1").addAliases("alias2").addAliases("alias3")
-                .setOrderDate(com.google.type.Date.newBuilder().setYear(1996).setMonth(11).setDay(11))
+                .setOrderDate(Date.newBuilder().setYear(1996).setMonth(11).setDay(11))
+                .setProperties(Struct.newBuilder().putFields("name", Value.newBuilder().setStringValue("John").build())
+                        .putFields("age", Value.newBuilder().setStringValue("50").build()).build())
+                .addAttributes(Struct.newBuilder().putFields("name", Value.newBuilder().setStringValue("John").build())
+                        .putFields("age", Value.newBuilder().setStringValue("50").build()).build())
+                .addAttributes(Struct.newBuilder().putFields("name", Value.newBuilder().setStringValue("John").build())
+                        .putFields("age", Value.newBuilder().setStringValue("50").build()).build())
+                .addUpdatedAt(createdAt)
+                .addUpdatedAt(createdAt)
                 .build();
+    }
+
+    @Test
+    public void shouldReturnStructField() {
+        Descriptors.FieldDescriptor structDesc = message.getDescriptorForType().findFieldByNumber(13);
+        ProtoField protoField = FieldFactory.getField(structDesc, message.getField(structDesc));
+        assertEquals(StructField.class.getName(), protoField.getClass().getName());
+
+        structDesc = message.getDescriptorForType().findFieldByNumber(16);
+        protoField = FieldFactory.getField(structDesc, message.getField(structDesc));
+        assertEquals(StructField.class.getName(), protoField.getClass().getName());
     }
 
     @Test
     public void shouldReturnTimestampField() {
         Descriptors.FieldDescriptor timestampDesc = message.getDescriptorForType().findFieldByNumber(4);
-
         ProtoField protoField = FieldFactory.getField(timestampDesc, message.getField(timestampDesc));
-
         assertEquals(TimestampField.class.getName(), protoField.getClass().getName());
+
+        Descriptors.FieldDescriptor timestampRepeatedDesc = message.getDescriptorForType().findFieldByNumber(15);
+        ProtoField protoFieldRepeated = FieldFactory.getField(timestampRepeatedDesc, message.getField(timestampRepeatedDesc));
+        assertEquals(TimestampField.class.getName(), protoFieldRepeated.getClass().getName());
     }
 
     @Test

--- a/src/test/java/com/gojek/beast/protomapping/ParserTest.java
+++ b/src/test/java/com/gojek/beast/protomapping/ParserTest.java
@@ -146,7 +146,7 @@ public class ParserTest {
     }
 
     private void assertTestMessage(List<ProtoField> fields) {
-        assertEquals(14, fields.size());
+        assertEquals(16, fields.size());
         assertField(fields.get(0), "order_number", DescriptorProtos.FieldDescriptorProto.Type.TYPE_STRING, DescriptorProtos.FieldDescriptorProto.Label.LABEL_OPTIONAL, 1);
         assertField(fields.get(1), "order_url", DescriptorProtos.FieldDescriptorProto.Type.TYPE_STRING, DescriptorProtos.FieldDescriptorProto.Label.LABEL_OPTIONAL, 2);
         assertField(fields.get(2), "order_details", DescriptorProtos.FieldDescriptorProto.Type.TYPE_STRING, DescriptorProtos.FieldDescriptorProto.Label.LABEL_OPTIONAL, 3);
@@ -161,6 +161,8 @@ public class ParserTest {
         assertField(fields.get(11), "aliases", DescriptorProtos.FieldDescriptorProto.Type.TYPE_STRING, DescriptorProtos.FieldDescriptorProto.Label.LABEL_REPEATED, 12);
         assertField(fields.get(12), "properties", DescriptorProtos.FieldDescriptorProto.Type.TYPE_MESSAGE, DescriptorProtos.FieldDescriptorProto.Label.LABEL_OPTIONAL, 13);
         assertField(fields.get(13), "order_date", DescriptorProtos.FieldDescriptorProto.Type.TYPE_MESSAGE, DescriptorProtos.FieldDescriptorProto.Label.LABEL_OPTIONAL, 14);
+        assertField(fields.get(14), "updated_at", DescriptorProtos.FieldDescriptorProto.Type.TYPE_MESSAGE, DescriptorProtos.FieldDescriptorProto.Label.LABEL_REPEATED, 15);
+        assertField(fields.get(15), "attributes", DescriptorProtos.FieldDescriptorProto.Type.TYPE_MESSAGE, DescriptorProtos.FieldDescriptorProto.Label.LABEL_REPEATED, 16);
 
         assertEquals(String.format(".%s", Duration.getDescriptor().getFullName()), fields.get(10).getTypeName());
         assertEquals(2, fields.get(10).getFields().size());

--- a/src/test/java/com/gojek/beast/util/ProtoUtil.java
+++ b/src/test/java/com/gojek/beast/util/ProtoUtil.java
@@ -22,6 +22,8 @@ public class ProtoUtil {
                 .setCreatedAt(createdAt)
                 .setStatus(Status.COMPLETED)
                 .setTripDuration(Duration.newBuilder().setSeconds(1).setNanos(TRIP_DURATION_NANOS).build())
+                .addUpdatedAt(createdAt)
+                .addUpdatedAt(createdAt)
                 .build();
 
     }

--- a/src/test/proto/TestMessage.proto
+++ b/src/test/proto/TestMessage.proto
@@ -31,6 +31,8 @@ message TestMessage {
     repeated string aliases = 12;
     google.protobuf.Struct properties = 13;
     google.type.Date order_date = 14;
+    repeated google.protobuf.Timestamp updated_at = 15;
+    repeated google.protobuf.Struct attributes = 16;
 }
 
 message TestNestedMessage {


### PR DESCRIPTION
Beasts fail to serialize struct type with repeated fields at the moment and throws a Cast exception. The same goes for repeated fields for Timestamp, both will be handled in this commit.
Empty BQ label crashes beast, that should be fixed as well. 