### PR TITLE
Make BQ Dataset location configurable (default=US)

### DIFF
--- a/src/main/java/com/gojek/beast/config/BQConfig.java
+++ b/src/main/java/com/gojek/beast/config/BQConfig.java
@@ -49,4 +49,8 @@ public interface BQConfig extends Config {
     @DefaultValue("-1")
     @Key("BQ_TABLE_PARTITION_EXPIRY_MILLIS")
     Long getBQTablePartitionExpiryMillis();
+
+    @DefaultValue("US")
+    @Key("BQ_DATASET_LOCATION")
+    String getBQDatasetLocation();
 }

--- a/src/main/java/com/gojek/beast/exception/BQDatasetLocationChangedException.java
+++ b/src/main/java/com/gojek/beast/exception/BQDatasetLocationChangedException.java
@@ -1,0 +1,8 @@
+package com.gojek.beast.exception;
+
+public class BQDatasetLocationChangedException extends RuntimeException {
+    public BQDatasetLocationChangedException(String message) {
+        super(message);
+    }
+}
+

--- a/src/main/java/com/gojek/beast/protomapping/ProtoUpdateListener.java
+++ b/src/main/java/com/gojek/beast/protomapping/ProtoUpdateListener.java
@@ -7,6 +7,7 @@ import com.gojek.beast.config.ProtoMappingConfig;
 import com.gojek.beast.config.StencilConfig;
 import com.gojek.beast.converter.ConsumerRecordConverter;
 import com.gojek.beast.converter.RowMapper;
+import com.gojek.beast.exception.BQDatasetLocationChangedException;
 import com.gojek.beast.exception.BQPartitionKeyNotSpecified;
 import com.gojek.beast.exception.BQSchemaMappingException;
 import com.gojek.beast.exception.BQTableUpdateFailure;
@@ -88,7 +89,8 @@ public class ProtoUpdateListener extends com.gojek.de.stencil.cache.ProtoUpdateL
             ProtoField protoField = protoFieldFactory.getProtoField();
             protoField = protoMappingParser.parseFields(protoField, proto, StencilUtils.getAllProtobufDescriptors(newDescriptors), StencilUtils.getTypeNameToPackageNameMap(newDescriptors));
             updateProtoParser(protoField);
-        } catch (BigQueryException | ProtoNotFoundException | BQSchemaMappingException | BQPartitionKeyNotSpecified | IOException e) {
+        } catch (BigQueryException | ProtoNotFoundException | BQSchemaMappingException | BQPartitionKeyNotSpecified
+                | BQDatasetLocationChangedException | IOException e) {
             String errMsg = "Error while updating bigquery table on callback:" + e.getMessage();
             log.error(errMsg);
             statsClient.increment("bq.table.upsert.failures");

--- a/src/test/java/com/gojek/beast/protomapping/BQClientTest.java
+++ b/src/test/java/com/gojek/beast/protomapping/BQClientTest.java
@@ -2,6 +2,7 @@ package com.gojek.beast.protomapping;
 
 import com.gojek.beast.config.BQConfig;
 import com.gojek.beast.config.Constants;
+import com.gojek.beast.exception.BQDatasetLocationChangedException;
 import com.gojek.beast.sink.bq.BQClient;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.Field;
@@ -50,6 +51,7 @@ public class BQClientTest {
         when(bqConfig.getBQTablePartitionExpiryMillis()).thenReturn(-1L);
         when(bqConfig.getTable()).thenReturn("bq-table");
         when(bqConfig.getDataset()).thenReturn("bq-proto");
+        when(bqConfig.getBQDatasetLocation()).thenReturn("US");
         bqClient = new BQClient(bigquery, bqConfig);
 
         ArrayList<Field> bqSchemaFields = new ArrayList<Field>() {{
@@ -73,7 +75,7 @@ public class BQClientTest {
         when(bigquery.create(tableInfo)).thenReturn(table);
 
         bqClient.upsertTable(bqSchemaFields);
-        verify(bigquery).create(DatasetInfo.of(tableId.getDataset()));
+        verify(bigquery).create(DatasetInfo.newBuilder(tableId.getDataset()).setLocation("US").build());
         verify(bigquery).create(tableInfo);
         verify(bigquery, never()).update(tableInfo);
     }
@@ -85,6 +87,7 @@ public class BQClientTest {
         when(bqConfig.getBQTablePartitionExpiryMillis()).thenReturn(-1L);
         when(bqConfig.getTable()).thenReturn("bq-table");
         when(bqConfig.getDataset()).thenReturn("bq-proto");
+        when(bqConfig.getBQDatasetLocation()).thenReturn("US");
         bqClient = new BQClient(bigquery, bqConfig);
 
         ArrayList<Field> bqSchemaFields = new ArrayList<Field>() {{
@@ -101,6 +104,7 @@ public class BQClientTest {
         TableInfo tableInfo = TableInfo.newBuilder(tableId, tableDefinition).build();
         when(bigquery.getDataset(tableId.getDataset())).thenReturn(dataset);
         when(dataset.exists()).thenReturn(true);
+        when(dataset.getLocation()).thenReturn("US");
         when(table.exists()).thenReturn(false);
         when(bigquery.getTable(tableId)).thenReturn(table);
         when(bigquery.create(tableInfo)).thenReturn(table);
@@ -115,6 +119,7 @@ public class BQClientTest {
         when(bqConfig.isBQTablePartitioningEnabled()).thenReturn(false);
         when(bqConfig.getTable()).thenReturn("bq-table");
         when(bqConfig.getDataset()).thenReturn("bq-proto");
+        when(bqConfig.getBQDatasetLocation()).thenReturn("US");
         bqClient = new BQClient(bigquery, bqConfig);
 
         ArrayList<Field> bqSchemaFields = new ArrayList<Field>() {{
@@ -132,6 +137,7 @@ public class BQClientTest {
         TableInfo tableInfo = TableInfo.newBuilder(tableId, tableDefinition).build();
         when(bigquery.getDataset(tableId.getDataset())).thenReturn(dataset);
         when(dataset.exists()).thenReturn(true);
+        when(dataset.getLocation()).thenReturn("US");
         when(table.exists()).thenReturn(false);
         when(bigquery.getTable(tableId)).thenReturn(table);
         when(table.exists()).thenReturn(false);
@@ -149,6 +155,7 @@ public class BQClientTest {
         when(bqConfig.getBQTablePartitionExpiryMillis()).thenReturn(-1L);
         when(bqConfig.getTable()).thenReturn("bq-table");
         when(bqConfig.getDataset()).thenReturn("bq-proto");
+        when(bqConfig.getBQDatasetLocation()).thenReturn("US");
         bqClient = new BQClient(bigquery, bqConfig);
 
         ArrayList<Field> bqSchemaFields = new ArrayList<Field>() {{
@@ -167,6 +174,7 @@ public class BQClientTest {
         TableInfo tableInfo = TableInfo.newBuilder(tableId, tableDefinition).build();
         when(bigquery.getDataset(tableId.getDataset())).thenReturn(dataset);
         when(dataset.exists()).thenReturn(true);
+        when(dataset.getLocation()).thenReturn("US");
         when(table.exists()).thenReturn(true);
         when(bigquery.getTable(tableId)).thenReturn(table);
         when(table.getDefinition()).thenReturn(mockTableDefinition);
@@ -185,6 +193,7 @@ public class BQClientTest {
         when(bqConfig.getBQTablePartitionExpiryMillis()).thenReturn(-1L);
         when(bqConfig.getTable()).thenReturn("bq-table");
         when(bqConfig.getDataset()).thenReturn("bq-proto");
+        when(bqConfig.getBQDatasetLocation()).thenReturn("US");
         bqClient = new BQClient(bigquery, bqConfig);
 
         ArrayList<Field> bqSchemaFields = new ArrayList<Field>() {{
@@ -207,6 +216,7 @@ public class BQClientTest {
         TableInfo tableInfo = TableInfo.newBuilder(tableId, updatedBQTableDefinition).build();
         when(bigquery.getDataset(tableId.getDataset())).thenReturn(dataset);
         when(dataset.exists()).thenReturn(true);
+        when(dataset.getLocation()).thenReturn("US");
         when(table.exists()).thenReturn(true);
         when(bigquery.getTable(tableId)).thenReturn(table);
         when(table.getDefinition()).thenReturn(mockTableDefinition);
@@ -228,6 +238,7 @@ public class BQClientTest {
         when(bqConfig.getBQTablePartitionExpiryMillis()).thenReturn(partitionExpiry);
         when(bqConfig.isBQTablePartitioningEnabled()).thenReturn(true);
         when(bqConfig.getBQTablePartitionKey()).thenReturn("partition_column");
+        when(bqConfig.getBQDatasetLocation()).thenReturn("US");
         bqClient = new BQClient(bigquery, bqConfig);
 
         ArrayList<Field> bqSchemaFields = new ArrayList<Field>() {{
@@ -246,6 +257,7 @@ public class BQClientTest {
         TableInfo tableInfo = TableInfo.newBuilder(tableId, tableDefinition).build();
         when(bigquery.getDataset(tableId.getDataset())).thenReturn(dataset);
         when(dataset.exists()).thenReturn(true);
+        when(dataset.getLocation()).thenReturn("US");
         when(table.exists()).thenReturn(true);
         when(bigquery.getTable(tableId)).thenReturn(table);
         when(table.getDefinition()).thenReturn(mockTableDefinition);
@@ -266,6 +278,7 @@ public class BQClientTest {
         when(bqConfig.getBQTablePartitionExpiryMillis()).thenReturn(-1L);
         when(bqConfig.getTable()).thenReturn("bq-table");
         when(bqConfig.getDataset()).thenReturn("bq-proto");
+        when(bqConfig.getBQDatasetLocation()).thenReturn("US");
 
         ArrayList<Field> bqSchemaFields = new ArrayList<Field>() {{
             add(Field.newBuilder("test-1", LegacySQLTypeName.INTEGER).setMode(Field.Mode.NULLABLE).build());
@@ -287,6 +300,7 @@ public class BQClientTest {
         TableInfo tableInfo = TableInfo.newBuilder(tableId, updatedBQTableDefinition).build();
         when(bigquery.getDataset(tableId.getDataset())).thenReturn(dataset);
         when(dataset.exists()).thenReturn(true);
+        when(dataset.getLocation()).thenReturn("US");
         when(table.exists()).thenReturn(true);
         when(bigquery.getTable(tableId)).thenReturn(table);
         when(table.getDefinition()).thenReturn(mockTableDefinition);
@@ -296,6 +310,38 @@ public class BQClientTest {
 
         bqClient = new BQClient(bigquery, bqConfig);
         bqClient.upsertTable(updatedBQSchemaFields);
+    }
+
+    @Test(expected = BQDatasetLocationChangedException.class)
+    public void shouldThrowExceptionIfDatasetLocationIsChanged() {
+        when(bqConfig.isBQTablePartitioningEnabled()).thenReturn(false);
+        when(bqConfig.getBQTablePartitionExpiryMillis()).thenReturn(-1L);
+        when(bqConfig.getTable()).thenReturn("bq-table");
+        when(bqConfig.getDataset()).thenReturn("bq-proto");
+        when(bqConfig.getBQDatasetLocation()).thenReturn("new-location");
+        bqClient = new BQClient(bigquery, bqConfig);
+
+        ArrayList<Field> bqSchemaFields = new ArrayList<Field>() {{
+            add(Field.newBuilder("test-1", LegacySQLTypeName.INTEGER).setMode(Field.Mode.NULLABLE).build());
+            add(Field.newBuilder("test-2", LegacySQLTypeName.STRING).setMode(Field.Mode.NULLABLE).build());
+            add(Field.newBuilder(Constants.OFFSET_COLUMN_NAME, LegacySQLTypeName.INTEGER).setMode(Field.Mode.NULLABLE).build());
+            add(Field.newBuilder(Constants.TOPIC_COLUMN_NAME, LegacySQLTypeName.STRING).setMode(Field.Mode.NULLABLE).build());
+            add(Field.newBuilder(Constants.LOAD_TIME_COLUMN_NAME, LegacySQLTypeName.TIMESTAMP).setMode(Field.Mode.NULLABLE).build());
+            add(Field.newBuilder(Constants.TIMESTAMP_COLUMN_NAME, LegacySQLTypeName.TIMESTAMP).setMode(Field.Mode.NULLABLE).build());
+            add(Field.newBuilder(Constants.PARTITION_COLUMN_NAME, LegacySQLTypeName.INTEGER).setMode(Field.Mode.NULLABLE).build());
+        }};
+
+        TableDefinition tableDefinition = getPartitionedTableDefinition(bqSchemaFields);
+        TableId tableId = TableId.of(bqConfig.getDataset(), bqConfig.getTable());
+        TableInfo tableInfo = TableInfo.newBuilder(tableId, tableDefinition).build();
+
+        when(bigquery.getDataset(tableId.getDataset())).thenReturn(dataset);
+        when(dataset.exists()).thenReturn(true);
+        when(dataset.getLocation()).thenReturn("US");
+
+        bqClient.upsertTable(bqSchemaFields);
+        verify(bigquery, never()).create(tableInfo);
+        verify(bigquery, never()).update(tableInfo);
     }
 
     private TableDefinition getPartitionedTableDefinition(ArrayList<Field> bqSchemaFields) {

--- a/src/test/java/com/gojek/beast/protomapping/ProtoUpdateListenerTest.java
+++ b/src/test/java/com/gojek/beast/protomapping/ProtoUpdateListenerTest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.gojek.beast.TestKey;
 import com.gojek.beast.config.*;
+import com.gojek.beast.exception.BQDatasetLocationChangedException;
 import com.gojek.beast.exception.BQTableUpdateFailure;
 import com.gojek.beast.exception.ProtoNotFoundException;
 import com.gojek.beast.models.ProtoField;
@@ -151,6 +152,43 @@ public class ProtoUpdateListenerTest {
             add(Field.newBuilder(Constants.PARTITION_COLUMN_NAME, LegacySQLTypeName.INTEGER).setMode(Field.Mode.NULLABLE).build());
         }};
         doThrow(new BigQueryException(10, "bigquery mapping has failed")).when(bqInstance).upsertTable(bqSchemaFields);
+
+        protoUpdateListener.onProtoUpdate(stencilConfig.getStencilUrl(), descriptorsMap);
+    }
+
+    @Test(expected = BQTableUpdateFailure.class)
+    public void shouldThrowExceptionIfDatasetLocationIsChanged() throws IOException {
+        ProtoField returnedProtoField = new ProtoField();
+        when(protoFieldFactory.getProtoField()).thenReturn(returnedProtoField);
+        returnedProtoField.addField(new ProtoField("order_number", 1));
+        returnedProtoField.addField(new ProtoField("order_url", 2));
+
+        HashMap<String, DescriptorAndTypeName> descriptorsMap = new HashMap<String, DescriptorAndTypeName>() {{
+            put(String.format("%s.%s", TestKey.class.getPackage(), TestKey.class.getName()), new DescriptorAndTypeName(TestKey.getDescriptor(), String.format(".%s.%s", TestKey.getDescriptor().getFile().getPackage(), TestKey.getDescriptor().getName())));
+        }};
+        when(protoMappingParser.parseFields(returnedProtoField, stencilConfig.getProtoSchema(), StencilUtils.getAllProtobufDescriptors(descriptorsMap), StencilUtils.getTypeNameToPackageNameMap(descriptorsMap))).thenReturn(returnedProtoField);
+        ObjectNode objNode = JsonNodeFactory.instance.objectNode();
+        objNode.put("1", "order_number");
+        objNode.put("2", "order_url");
+        String expectedProtoMapping = objectMapper.writeValueAsString(objNode);
+        when(protoMappingConverter.generateColumnMappings(returnedProtoField.getFields())).thenReturn(expectedProtoMapping);
+
+        ArrayList<Field> returnedSchemaFields = new ArrayList<Field>() {{
+            add(Field.newBuilder("order_number", LegacySQLTypeName.INTEGER).setMode(Field.Mode.NULLABLE).build());
+            add(Field.newBuilder("order_url", LegacySQLTypeName.STRING).setMode(Field.Mode.NULLABLE).build());
+        }};
+        when(protoMappingConverter.generateBigquerySchema(returnedProtoField)).thenReturn(returnedSchemaFields);
+
+        ArrayList<Field> bqSchemaFields = new ArrayList<Field>() {{
+            add(Field.newBuilder("order_number", LegacySQLTypeName.INTEGER).setMode(Field.Mode.NULLABLE).build());
+            add(Field.newBuilder("order_url", LegacySQLTypeName.STRING).setMode(Field.Mode.NULLABLE).build());
+            add(Field.newBuilder(Constants.OFFSET_COLUMN_NAME, LegacySQLTypeName.INTEGER).setMode(Field.Mode.NULLABLE).build());
+            add(Field.newBuilder(Constants.TOPIC_COLUMN_NAME, LegacySQLTypeName.STRING).setMode(Field.Mode.NULLABLE).build());
+            add(Field.newBuilder(Constants.LOAD_TIME_COLUMN_NAME, LegacySQLTypeName.TIMESTAMP).setMode(Field.Mode.NULLABLE).build());
+            add(Field.newBuilder(Constants.TIMESTAMP_COLUMN_NAME, LegacySQLTypeName.TIMESTAMP).setMode(Field.Mode.NULLABLE).build());
+            add(Field.newBuilder(Constants.PARTITION_COLUMN_NAME, LegacySQLTypeName.INTEGER).setMode(Field.Mode.NULLABLE).build());
+        }};
+        doThrow(new BQDatasetLocationChangedException("cannot change dataset location")).when(bqInstance).upsertTable(bqSchemaFields);
 
         protoUpdateListener.onProtoUpdate(stencilConfig.getStencilUrl(), descriptorsMap);
     }


### PR DESCRIPTION
By default, we've been creating Dataset into US region. With this change, we can choose a region (location) for a dataset using BQ_DATASET_LOCATION variable.

Also, since a BQ's dataset's location cannot be changed once created, beast will throw an exception is the location is changed from the created location. 