### PR TITLE
[Kush] Re-throw exception for RowMapper

### DIFF
--- a/src/main/java/com/gojek/beast/converter/RowMapper.java
+++ b/src/main/java/com/gojek/beast/converter/RowMapper.java
@@ -71,6 +71,7 @@ public class RowMapper {
                         fieldValue = getMappings((DynamicMessage) field, (ColumnMapping) value);
                     } catch (Exception e) {
                         log.error("Exception::Handling nested field failure: {}", e.getMessage());
+                        throw e;
                     }
                 }
                 row.put(columnName, fieldValue);


### PR DESCRIPTION
When a nested field contains unknown fields, exceptions were getting absorbed. This should rethrow the exception and fail the deployment. If not done, can cause nested fields to be ignored and data loss.